### PR TITLE
fix deployment strategy type

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: codex-docs
 description: A Helm chart for CodeX Docs
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.2.0"

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -5,9 +5,12 @@ metadata:
   labels:
     {{- include "codexdocs.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
+{{/*  {{- if not .Values.autoscaling.enabled }}*/}}
+{{/*  replicas: {{ .Values.replicaCount }}*/}}
+{{/*  {{- end }}*/}}
+  replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "codexdocs.selectorLabels" . | nindent 6 }}

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-replicaCount: 1
+#replicaCount: 1
 
 configuration:
   codexdocsrc:
@@ -74,12 +74,6 @@ ingress:
   tls: []
 
 resources: {}
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
 
 nodeSelector: {}
 


### PR DESCRIPTION
We can't use rolling updates because there is persistent volume mount, which can't be mounted to new pod during update. So we need firstly remove old image and then create new one